### PR TITLE
fix: show loading state while parsing voice input

### DIFF
--- a/components/tasks/TaskForm.js
+++ b/components/tasks/TaskForm.js
@@ -92,10 +92,18 @@ export default function TaskForm({
 
         {!initialData && (
           <div className={styles.voiceSection}>
-            <VoiceMic onResult={processVoiceInput} />
+            <VoiceMic
+              onResult={processVoiceInput}
+              disabled={isProcessingVoice}
+            />
             <div className={styles.voiceHint}>
               {isProcessingVoice ? (
-                <span className={styles.voiceActive}>
+                <span
+                  className={styles.voiceActive}
+                  role="status"
+                  aria-live="polite"
+                >
+                  <span className={styles.voiceSpinner} aria-hidden="true" />
                   Parsing your request with AI...
                 </span>
               ) : voiceInput ? (

--- a/components/tasks/TaskForm.module.css
+++ b/components/tasks/TaskForm.module.css
@@ -84,9 +84,22 @@
 }
 
 .voiceActive {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   color: var(--color-info);
   font-weight: 500;
   animation: pulseText 1.5s ease-in-out infinite;
+}
+
+.voiceSpinner {
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(99, 102, 241, 0.25);
+  border-top-color: var(--color-info);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  flex-shrink: 0;
 }
 
 /* ── Form body ── */
@@ -161,5 +174,11 @@
   }
   50% {
     opacity: 0.4;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
   }
 }


### PR DESCRIPTION
Summary:
- Add an inline spinner and live status message while the voice parse request is running.
- Disable the voice mic while parsing to avoid duplicate parse requests.

Closes #5

Validation:
- npm run lint passes with existing warnings outside this change.
- npm run build passes.