### PR TITLE
Fix #30: Add Escape key support for Add/Edit task modals

### DIFF
--- a/components/tasks/TaskForm.js
+++ b/components/tasks/TaskForm.js
@@ -34,6 +34,24 @@ export default function TaskForm({
       processVoiceInput(initialVoiceText);
     }
   }, [initialVoiceText]);
+  // Listen for Escape key presses and dismiss the active modal.
+  // Cleanup removes the listener when the modal unmounts.
+
+  useEffect(() => {
+    if (!onClose) return;
+
+    const handleEscape = (e) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleEscape);
+
+    return () => {
+      window.removeEventListener('keydown', handleEscape);
+    };
+  }, [onClose]);
 
   const processVoiceInput = async (text) => {
     setVoiceInput(text);


### PR DESCRIPTION
## Description

This PR adds keyboard support for dismissing task modals using the Escape key.

### Changes Made

* Added a window-level `keydown` listener in `TaskForm`.
* Closes the active modal when the Escape key is pressed.
* Removes the event listener during cleanup when the modal is closed/unmounted.

### Acceptance Criteria Covered

* Pressing `Esc` closes any active Add/Edit task modal.
* No state issues occur after modal closure due to proper listener cleanup.

### Verification

* Project successfully builds using `npm run build`.
* No new lint issues introduced by this change.
