### PR TITLE
fix: improve accessibility for Add/Edit Task modals

### DIFF
--- a/components/tasks/TaskForm.js
+++ b/components/tasks/TaskForm.js
@@ -35,6 +35,20 @@ export default function TaskForm({
     }
   }, [initialVoiceText]);
 
+  useEffect(() => {
+    const handleEsc = (e) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleEsc);
+
+    return () => {
+      window.removeEventListener('keydown', handleEsc);
+    };
+  }, [onClose]);
+
   const processVoiceInput = async (text) => {
     setVoiceInput(text);
     setIsProcessingVoice(true);
@@ -167,6 +181,7 @@ export default function TaskForm({
                   </label>
                   <select
                     id="priority"
+                    aria-label="Task priority"
                     className={styles.select}
                     value={priority}
                     onChange={(e) => setPriority(e.target.value)}
@@ -183,6 +198,7 @@ export default function TaskForm({
                   </label>
                   <select
                     id="category"
+                    aria-label="Task category"
                     className={styles.select}
                     value={category}
                     onChange={(e) => setCategory(e.target.value)}


### PR DESCRIPTION
## Changes Made
- Added Escape key support to close Add/Edit Task modals
- Added aria-labels to improve modal accessibility
- Tested modal close behavior locally

Fixes #4 