### PR TITLE
feat: add mute toggle for notification chimes

### DIFF
--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -18,6 +18,7 @@ export default function DashboardPage() {
   const [editingTask, setEditingTask] = useState(null);
   const [initialVoiceText, setInitialVoiceText] = useState("");
   const [loading, setLoading] = useState(true);
+  const [muted, setMuted] = useState(false);
 
   useEscalationEngine(tasks);
 
@@ -36,6 +37,14 @@ export default function DashboardPage() {
       }
     };
     fetchTasks();
+  }, []);
+
+  useEffect(() => {
+    const saved =
+      typeof window !== "undefined" &&
+      localStorage.getItem("notificationsMuted") === "true";
+
+    setMuted(saved);
   }, []);
 
   const stats = useMemo(
@@ -120,6 +129,14 @@ export default function DashboardPage() {
     setIsFormOpen(true);
   };
 
+  const toggleMute = () => {
+    const newValue = !muted;
+
+    setMuted(newValue);
+
+    localStorage.setItem("notificationsMuted", newValue.toString());
+  };
+
   const handleSaveTask = async (taskData) => {
     try {
       if (editingTask) {
@@ -182,6 +199,16 @@ export default function DashboardPage() {
           <h1 className={styles.title}>Your Tasks</h1>
         </div>
         <div className={styles.headerActions}>
+          <Button
+            variant="ghost"
+            size="md"
+            onClick={toggleMute}
+            aria-label={
+              muted ? "Unmute notification sounds" : "Mute notification sounds"
+            }
+          >
+            {muted ? "🔇 Muted" : "🔊 Sound"}
+          </Button>
           <VoiceMic onResult={handleVoiceInput} />
           <Button
             variant="primary"

--- a/components/hooks/useEscalationEngine.js
+++ b/components/hooks/useEscalationEngine.js
@@ -65,7 +65,11 @@ export default function useEscalationEngine(tasks) {
         }
       });
 
-      if (shouldPlayChime) {
+      const muted =
+        typeof window !== 'undefined' &&
+        localStorage.getItem('notificationsMuted') === 'true';
+
+      if (shouldPlayChime && !muted) {
         // Try to play a generic system beep or loaded sound
         try {
           const audioCtx = new (


### PR DESCRIPTION
## Changes Made
- Added mute/unmute toggle in dashboard header
- Persisted notification sound preference using localStorage
- Updated escalation sound engine to respect mute state
- Tested persistence and toggle behavior locally

Fixes #27 