### PR TITLE
docs: add contribution leaderboard link to CONTRIBUTING.md (fixes #80)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,14 @@ If you've noticed a bug or have a feature request, please make sure to check if 
 3. **Describe your changes**: Fill out the PR template carefully, linking any related issues.
 4. **Code Review**: The maintainers will review your PR and may suggest changes. Once approved, your PR will be merged!
 
+## Contribution Leaderboard
+
+Want to see how your contributions stack up? Check out the live contributor scoreboard for RemindKaro:
+
+ **[View Contribution Leaderboard](https://github.com/Remind-Karo/RemindKaro/graphs/contributors)**
+
+This leaderboard is powered by GitHub's native contribution metrics and updates automatically with every merged commit. Climb the ranks by fixing bugs, adding features, or improving documentation!
+
 ## Contact
 
 If you have any questions, feel free to reach out to the project owner:


### PR DESCRIPTION
## Summary
Closes #80

## What changed
Added a `## Contribution Leaderboard` section to `CONTRIBUTING.md` linking to the GitHub-native contributors graph at:
https://github.com/Remind-Karo/RemindKaro/graphs/contributors

## Why
Contributors want a fast route to see where they rank. This places a clearly visible markdown link near the developer guidelines (between the PR submission steps and the Contact section), satisfying the acceptance criteria of:
- Clear markdown link directed to active GitHub metrics ✅
- Positioned visibly near developer guidelines ✅

## Type of change
- [x] Documentation update (no code changes)

## Checklist
- [x] Linked to issue #80
- [x] No existing content modified or removed
- [x] Follows the existing CONTRIBUTING.md formatting style