### PR TITLE
feat: add contributor guidelines quick links to footer - Issue #59

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ If you've noticed a bug or have a feature request, please make sure to check if 
 
 Want to see how your contributions stack up? Check out the live contributor scoreboard for RemindKaro:
 
- **[View Contribution Leaderboard](https://github.com/Remind-Karo/RemindKaro/graphs/contributors)**
+**[View Contribution Leaderboard](https://github.com/Remind-Karo/RemindKaro/graphs/contributors)**
 
 This leaderboard is powered by GitHub's native contribution metrics and updates automatically with every merged commit. Climb the ranks by fixing bugs, adding features, or improving documentation!
 

--- a/components/ui/Footer.js
+++ b/components/ui/Footer.js
@@ -56,6 +56,38 @@ export default function Footer() {
           </div>
 
           <div>
+            <h3 className={styles.colTitle}>Project Guidelines</h3>
+            <ul className={styles.linkList}>
+              <li>
+                <a
+                  href="https://github.com/Remind-Karo/RemindKaro/blob/main/CONTRIBUTING.md"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Contributing Guidelines
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/Remind-Karo/RemindKaro/blob/main/CODE_OF_CONDUCT.md"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Code of Conduct
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/Remind-Karo/RemindKaro/blob/main/SECURITY.md"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Security Policy
+                </a>
+              </li>
+            </ul>
+          </div>
+          <div>
             <h3 className={styles.colTitle}>Contact</h3>
             <a href="mailto:hello@remindkaro.com" className={styles.contactBtn}>
               <Mail size={16} aria-hidden />


### PR DESCRIPTION
## What changed?
Added a new "Project Guidelines" column in the footer with links to:
- CONTRIBUTING.md
- CODE_OF_CONDUCT.md  
- SECURITY.md

The links open in new tabs and use the existing CSS styling.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Testing Checklist
- [x] I have run `npm run lint` and resolved all errors.
- [x] I have run `npm run format` to ensure code is formatted.
- [x] I have built the application locally and verified it works.
- [x] Tests pass locally (if applicable).

## Security Checklist
- [x] No hardcoded secrets, API keys, or tokens.
- [x] Domain validation for non-mandatory inputs

## Related Issue
Closes #59

## Screenshots
[Footer now shows Project Guidelines column with 3 links]
<img width="1919" height="1033" alt="Screenshot 2026-06-03 152205" src="https://github.com/user-attachments/assets/ee30375e-30c4-4156-bdd5-bdeafe678230" />
<img width="1915" height="1017" alt="Screenshot 2026-06-03 152233" src="https://github.com/user-attachments/assets/c3eb70f1-575e-41f3-b953-6e10dfdcb5a8" />
