### PR TITLE
feat: form default date autofill to next hour

### DIFF
--- a/components/tasks/TaskForm.js
+++ b/components/tasks/TaskForm.js
@@ -40,10 +40,16 @@ export default function TaskForm({
   const [description, setDescription] = useState(
     initialData?.description || ''
   );
+  const getNextHourDefault = () => {
+    const date = new Date();
+    date.setHours(date.getHours() + 1, 0, 0, 0);
+    return toLocalDateTimeValue(date);
+  };
+
   const [deadline, setDeadline] = useState(
     initialData?.deadline
       ? new Date(initialData.deadline).toISOString().slice(0, 16)
-      : ''
+      : getNextHourDefault()
   );
 
   const [deadlineWarning, setDeadlineWarning] = useState('');


### PR DESCRIPTION
Closes #76 - New task form deadline field now defaults to the next full hour instead of empty