### PR TITLE
feat: add no description placeholder on task cards

### DIFF
--- a/components/tasks/TaskCard.js
+++ b/components/tasks/TaskCard.js
@@ -94,8 +94,12 @@ export default function TaskCard({ task, onStatusChange, onDelete, onEdit }) {
           </span>
         </div>
 
-        {task.description && (
+        {task.description ? (
           <p className={styles.description}>{task.description}</p>
+        ) : (
+          <p className={styles.descriptionPlaceholder}>
+            No description provided
+          </p>
         )}
 
         <div className={styles.meta}>

--- a/components/tasks/TaskCard.module.css
+++ b/components/tasks/TaskCard.module.css
@@ -113,6 +113,14 @@
   margin: 0;
 }
 
+.descriptionPlaceholder {
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+  font-style: italic;
+  opacity: 0.5;
+  margin: 0;
+}
+
 /* ── Urgency Badge ── */
 .urgencyBadge {
   display: inline-flex;


### PR DESCRIPTION
Closes #78 - Tasks without descriptions now show italicized 'No description provided' placeholder instead of blank space