### PR TITLE
feat: add hover sound effect option for dashboard nav icons

### DIFF
--- a/app/dashboard/layout.js
+++ b/app/dashboard/layout.js
@@ -4,8 +4,16 @@ import Link from "next/link";
 import { useRouter, usePathname } from "next/navigation";
 import dynamic from "next/dynamic";
 import BrandLogo from "@/components/ui/BrandLogo";
+import { useHoverSound } from "@/components/hooks/useHoverSound";
 
 const ThemeToggle = dynamic(() => import("@/components/ui/ThemeToggle"), {
+  ssr: false,
+  loading: () => (
+    <div style={{ width: 44, height: 24 }} className="toggle-placeholder" />
+  ),
+});
+
+const SoundToggle = dynamic(() => import("@/components/ui/SoundToggle"), {
   ssr: false,
   loading: () => (
     <div style={{ width: 44, height: 24 }} className="toggle-placeholder" />
@@ -15,6 +23,7 @@ const ThemeToggle = dynamic(() => import("@/components/ui/ThemeToggle"), {
 export default function DashboardLayout({ children }) {
   const router = useRouter();
   const pathname = usePathname();
+  const playHoverSound = useHoverSound();
 
   const handleLogout = async () => {
     try {
@@ -35,6 +44,7 @@ export default function DashboardLayout({ children }) {
         <nav className={styles.nav}>
           <Link
             href="/dashboard"
+            onMouseEnter={playHoverSound}
             className={`${styles.navLink} ${pathname === "/dashboard" ? styles.active : ""}`}
           >
             <span className={styles.navLinkFull}>Dashboard</span>
@@ -44,6 +54,7 @@ export default function DashboardLayout({ children }) {
           </Link>
           <Link
             href="/dashboard/profile"
+            onMouseEnter={playHoverSound}
             className={`${styles.navLink} ${pathname === "/dashboard/profile" ? styles.active : ""}`}
           >
             <span className={styles.navLinkFull}>Profile</span>
@@ -53,6 +64,7 @@ export default function DashboardLayout({ children }) {
           </Link>
           <Link
             href="/dashboard/support"
+            onMouseEnter={playHoverSound}
             className={`${styles.navLink} ${pathname.startsWith("/dashboard/support") ? styles.active : ""}`}
           >
             <span className={styles.navLinkFull}>Support</span>
@@ -62,6 +74,7 @@ export default function DashboardLayout({ children }) {
           </Link>
           <Link
             href="/pricing"
+            onMouseEnter={playHoverSound}
             className={`${styles.navLink} ${pathname === "/pricing" ? styles.active : ""}`}
           >
             <span className={styles.navLinkFull}>Pricing</span>
@@ -70,6 +83,7 @@ export default function DashboardLayout({ children }) {
             </span>
           </Link>
           <ThemeToggle compact />
+          <SoundToggle compact />
           <div className={styles.navDivider} />
           <button onClick={handleLogout} className={styles.logoutBtn}>
             Sign out

--- a/components/hooks/useHoverSound.js
+++ b/components/hooks/useHoverSound.js
@@ -1,0 +1,43 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+import { useSound } from '@/components/providers/SoundProvider';
+
+export function useHoverSound() {
+  const { soundEnabled } = useSound();
+  const audioCtxRef = useRef(null);
+
+  const playHoverSound = useCallback(() => {
+    if (!soundEnabled) return;
+
+    try {
+      if (!audioCtxRef.current) {
+        const AudioContext = window.AudioContext || window.webkitAudioContext;
+        audioCtxRef.current = new AudioContext();
+      }
+      const ctx = audioCtxRef.current;
+
+      const oscillator = ctx.createOscillator();
+      const gainNode = ctx.createGain();
+
+      oscillator.type = 'sine';
+      oscillator.frequency.value = 1800; // high-frequency subtle click
+
+      gainNode.gain.setValueAtTime(0.04, ctx.currentTime); // very quiet
+      gainNode.gain.exponentialRampToValueAtTime(
+        0.0001,
+        ctx.currentTime + 0.08
+      );
+
+      oscillator.connect(gainNode);
+      gainNode.connect(ctx.destination);
+
+      oscillator.start(ctx.currentTime);
+      oscillator.stop(ctx.currentTime + 0.08);
+    } catch {
+      // Audio not supported or blocked — fail silently
+    }
+  }, [soundEnabled]);
+
+  return playHoverSound;
+}

--- a/components/providers/AppProviders.js
+++ b/components/providers/AppProviders.js
@@ -1,7 +1,12 @@
 'use client';
 
 import { ThemeProvider } from './ThemeProvider';
+import { SoundProvider } from './SoundProvider';
 
 export default function AppProviders({ children }) {
-  return <ThemeProvider>{children}</ThemeProvider>;
+  return (
+    <ThemeProvider>
+      <SoundProvider>{children}</SoundProvider>
+    </ThemeProvider>
+  );
 }

--- a/components/providers/SoundProvider.js
+++ b/components/providers/SoundProvider.js
@@ -1,0 +1,53 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+const STORAGE_KEY = 'remindkaro-sound';
+
+const SoundContext = createContext({
+  soundEnabled: false,
+  toggleSound: () => {},
+  mounted: false,
+});
+
+export function SoundProvider({ children }) {
+  const [soundEnabled, setSoundEnabled] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === 'true') {
+      setSoundEnabled(true);
+    }
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+    localStorage.setItem(STORAGE_KEY, soundEnabled ? 'true' : 'false');
+  }, [soundEnabled, mounted]);
+
+  const toggleSound = useCallback(() => {
+    setSoundEnabled((s) => !s);
+  }, []);
+
+  const value = useMemo(
+    () => ({ soundEnabled, toggleSound, mounted }),
+    [soundEnabled, mounted, toggleSound]
+  );
+
+  return (
+    <SoundContext.Provider value={value}>{children}</SoundContext.Provider>
+  );
+}
+
+export function useSound() {
+  return useContext(SoundContext);
+}

--- a/components/ui/SoundToggle.js
+++ b/components/ui/SoundToggle.js
@@ -1,0 +1,61 @@
+'use client';
+
+import { Volume2, VolumeX } from 'lucide-react';
+import { useSound } from '@/components/providers/SoundProvider';
+import styles from './ThemeToggle.module.css';
+
+export default function SoundToggle({ compact = false, className = '' }) {
+  const { soundEnabled, toggleSound, mounted } = useSound();
+
+  if (!mounted) {
+    return (
+      <div
+        className={[styles.toggle, compact ? styles.compact : '', className]
+          .filter(Boolean)
+          .join(' ')}
+        aria-hidden
+        style={{ opacity: 0.6 }}
+      />
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={[styles.toggle, compact ? styles.compact : '', className]
+        .filter(Boolean)
+        .join(' ')}
+      onClick={toggleSound}
+      aria-label={soundEnabled ? 'Disable hover sounds' : 'Enable hover sounds'}
+      title={soundEnabled ? 'Sound on' : 'Sound off'}
+    >
+      <span className={styles.srOnly}>
+        {soundEnabled ? 'Disable hover sounds' : 'Enable hover sounds'}
+      </span>
+      <span
+        className={[styles.thumb, !soundEnabled ? styles.thumbLight : ''].join(
+          ' '
+        )}
+        aria-hidden
+      />
+      <span
+        className={[
+          styles.iconSlot,
+          soundEnabled ? styles.iconSlotActive : '',
+        ].join(' ')}
+        aria-hidden
+      >
+        <Volume2 size={compact ? 14 : 16} />
+      </span>
+      <span
+        className={[
+          styles.iconSlot,
+          !soundEnabled ? styles.iconSlotActive : '',
+        ].join(' ')}
+        aria-hidden
+      >
+        <VolumeX size={compact ? 14 : 16} />
+      </span>
+    </button>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1620,7 +1620,7 @@
       "version": "25.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -7318,7 +7318,7 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {


### PR DESCRIPTION
## What changed?
Added an optional hover sound effect for dashboard navigation icons.

- Created SoundProvider (context for sound on/off state, persisted in localStorage)
- Created SoundToggle component (UI toggle, follows same pattern as ThemeToggle)
- Created useHoverSound hook using Web Audio API to play a quiet, high-frequency 
  click chime (1800Hz, very low volume, 80ms duration)
- Wired SoundProvider into AppProviders
- Added hover sound + SoundToggle to dashboard nav (Dashboard, Profile, Support, Pricing links)

The sound is:
- Highly subtle (volume 0.04, exponential decay)
- Off by default
- Respects the mute toggle state (only plays when soundEnabled is true)

Closes #75

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Security Checklist
- [x] No hardcoded secrets, API keys, or tokens.
- [x] No unintended data exposure in logs or UI.

## Screenshots (if applicable)
New sound toggle appears next to the theme toggle in the dashboard nav bar.