### PR TITLE
feat: autofill task deadline to next hour by default

### DIFF
--- a/components/tasks/TaskForm.js
+++ b/components/tasks/TaskForm.js
@@ -43,7 +43,12 @@ export default function TaskForm({
   const [deadline, setDeadline] = useState(
     initialData?.deadline
       ? new Date(initialData.deadline).toISOString().slice(0, 16)
-      : ''
+      : (() => {
+          const nextHour = new Date();
+          nextHour.setHours(nextHour.getHours() + 1);
+          nextHour.setMinutes(0, 0, 0);
+          return toLocalDateTimeValue(nextHour);
+        })()
   );
 
   const [deadlineWarning, setDeadlineWarning] = useState('');


### PR DESCRIPTION
## What changed?
When creating a new task, the deadline field now defaults to exactly 
1 hour from the current time, rounded to the top of the hour, instead 
of being blank.

- Editing an existing task is unaffected — it still uses the task's saved deadline.
- The autofilled value is fully editable, so users can still pick any other date/time.
- Reuses the existing toLocalDateTimeValue helper for consistent formatting.

Closes #76

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Security Checklist
- [x] No hardcoded secrets, API keys, or tokens.
- [x] No unintended data exposure in logs or UI.

## Screenshots (if applicable)
The "New Task" modal now opens with the deadline field pre-filled to 
1 hour from now instead of empty.