### PR TITLE
fix: add 'No description added' placeholder for empty task descriptions

### DIFF
--- a/components/tasks/TaskCard.js
+++ b/components/tasks/TaskCard.js
@@ -94,8 +94,12 @@ export default function TaskCard({ task, onStatusChange, onDelete, onEdit }) {
           </span>
         </div>
 
-        {task.description && (
+        {task.description ? (
           <p className={styles.description}>{task.description}</p>
+        ) : (
+          <p className={`${styles.description} ${styles.descriptionPlaceholder}`}>
+            No description added
+          </p>
         )}
 
         <div className={styles.meta}>

--- a/components/tasks/TaskCard.module.css
+++ b/components/tasks/TaskCard.module.css
@@ -113,6 +113,13 @@
   margin: 0;
 }
 
+.descriptionPlaceholder {
+  color: var(--color-text-tertiary);
+  opacity: 0.5;
+  font-style: italic;
+  font-size: 12px;
+}
+
 /* ── Urgency Badge ── */
 .urgencyBadge {
   display: inline-flex;


### PR DESCRIPTION
## Description

Tasks without description metadata display empty gaps in cards. This PR adds a light italicized placeholder string saying "No description added" when the description is empty.

## Changes
- Modified `TaskCard.js` to show a placeholder when `task.description` is falsy
- Added `descriptionPlaceholder` CSS class with slate-grey color, low opacity, and italic styling
- Placeholder does not affect grid layout sizes

## Fixes
Closes #78

## Testing
- [x] Placeholder renders when task has no description
- [x] Normal descriptions still render correctly
- [x] No layout shift or grid distortion