### PR TITLE
fix: update document title with pending task count

### DIFF
--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -20,6 +20,12 @@ export default function DashboardPage() {
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
 
+  // Dynamic document title with pending task count
+  useEffect(() => {
+    const pendingCount = tasks.filter((t) => t.status !== "completed" && t.status !== "archived").length;
+    document.title = pendingCount > 0 ? `(${pendingCount}) RemindKaro` : "RemindKaro";
+  }, [tasks]);
+
   useEscalationEngine(tasks);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

Users working in other tabs often forget their task backlog queue. This PR dynamically updates the browser tab title to display the number of active pending tasks.

## Changes
- Added `useEffect` hook in `DashboardPage` to update `document.title`
- Format: `(3) RemindKaro` when tasks are pending
- Reverts to `RemindKaro` when no pending tasks remain

## Fixes
Closes #67