### PR TITLE
fix: improve mobile dashboard layout

### DIFF
--- a/app/dashboard/page.module.css
+++ b/app/dashboard/page.module.css
@@ -174,17 +174,54 @@
     grid-template-columns: 1fr;
   }
 
+  .container {
+    gap: 24px;
+  }
+
   .title {
     font-size: 24px;
   }
 
   .header {
-    align-items: flex-start;
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .headerActions {
     width: 100%;
+    flex-wrap: wrap;
+    justify-content: stretch;
+  }
+
+  .headerActions > * {
+    flex: 1 1 100%;
+  }
+
+  .controls {
+    align-items: stretch;
+  }
+
+  .searchWrap,
+  .filterGroup,
+  .sortSelect,
+  .taskCount,
+  .clearBtn {
+    width: 100%;
+  }
+
+  .filterGroup {
     justify-content: space-between;
+    overflow-x: auto;
+  }
+
+  .filterBtn {
+    flex: 1 1 0;
+    min-height: 44px;
+    padding-inline: 10px;
+  }
+
+  .sidePanel {
+    position: static;
   }
 }
 

--- a/components/tasks/TaskCard.module.css
+++ b/components/tasks/TaskCard.module.css
@@ -252,10 +252,25 @@
     transform: none;
     pointer-events: all;
     flex-direction: row;
+    flex-wrap: wrap;
     margin-left: 0;
     margin-top: 10px;
   }
+
+  .actionBtn {
+    width: 44px;
+    height: 44px;
+  }
+
   .card {
     flex-direction: column;
+    width: 100%;
+    padding: 16px;
+  }
+
+  .topRow {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
   }
 }


### PR DESCRIPTION
## What changed?

Improves the mobile dashboard layout for #61 by stacking the header and action area below 640px, making the filter controls full-width, removing sticky sidebar behavior after the sidebar collapses, and increasing mobile task action buttons to 44px touch targets.

Closes #61

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring / Tech Debt
- [ ] CI/CD or Configuration changes

## Testing Checklist

- [x] I have run `npm run lint` and resolved all errors.
- [ ] I have run `npm run format` to ensure code is formatted.
- [x] I have built the application locally and verified it works.
- [x] Tests pass locally (if applicable).

Notes: I formatted the two touched CSS files with Prettier. The repo-wide `npm run format:check` currently reports pre-existing formatting differences in unrelated files, so I did not run a repo-wide format write.

## Security Checklist

- [x] No hardcoded secrets, API keys, or tokens.
- [x] Proper validation for any new user input.
- [x] No unintended data exposure in logs or UI.

## Screenshots (if applicable)

Dashboard visual verification needs a logged-in session. I verified the app starts locally and redirects unauthenticated `/dashboard` access to `/login` as expected.