### PR TITLE
fix: require task category selection

### DIFF
--- a/components/tasks/TaskCard.js
+++ b/components/tasks/TaskCard.js
@@ -105,7 +105,9 @@ export default function TaskCard({
         {task.description ? (
           <p className={styles.description}>{task.description}</p>
         ) : (
-          <p className={`${styles.description} ${styles.descriptionPlaceholder}`}>
+          <p
+            className={`${styles.description} ${styles.descriptionPlaceholder}`}
+          >
             No description added
           </p>
         )}

--- a/components/tasks/TaskForm.js
+++ b/components/tasks/TaskForm.js
@@ -60,7 +60,8 @@ export default function TaskForm({
   const deadlineError = isPastDeadline ? DEADLINE_ERROR : deadlineWarning;
 
   const [priority, setPriority] = useState(initialData?.priority || 'medium');
-  const [category, setCategory] = useState(initialData?.category || 'General');
+  const [category, setCategory] = useState(initialData?.category || '');
+  const [isCategoryInvalid, setIsCategoryInvalid] = useState(false);
   const [assigneeId, setAssigneeId] = useState(initialData?.assigneeId || '');
 
   const [isProcessingVoice, setIsProcessingVoice] = useState(false);
@@ -111,6 +112,7 @@ export default function TaskForm({
       );
       setPriority(data.priority);
       setCategory(data.category);
+      setIsCategoryInvalid(false);
     } catch (err) {
       console.error(err);
       // Fallback to basic assignment if API fails
@@ -126,6 +128,11 @@ export default function TaskForm({
     // Final date/time validation before saving
     if (isDeadlineInPast(deadline)) {
       setDeadlineWarning(DEADLINE_ERROR);
+      return;
+    }
+
+    if (!category) {
+      setIsCategoryInvalid(true);
       return;
     }
 
@@ -265,16 +272,42 @@ export default function TaskForm({
                   <select
                     id="category"
                     aria-label="Task category"
-                    className={styles.select}
+                    aria-describedby={
+                      isCategoryInvalid ? 'category-error' : undefined
+                    }
+                    aria-invalid={isCategoryInvalid}
+                    className={`${styles.select} ${
+                      isCategoryInvalid ? styles.selectError : ''
+                    }`}
                     value={category}
-                    onChange={(e) => setCategory(e.target.value)}
+                    onChange={(e) => {
+                      e.currentTarget.setCustomValidity('');
+                      setCategory(e.target.value);
+                      setIsCategoryInvalid(false);
+                    }}
+                    onInvalid={(e) => {
+                      e.currentTarget.setCustomValidity(
+                        'Please select a category.'
+                      );
+                      setIsCategoryInvalid(true);
+                    }}
+                    onInput={(e) => e.currentTarget.setCustomValidity('')}
+                    required
                   >
+                    <option value="" disabled>
+                      Select category
+                    </option>
                     <option value="General">General</option>
                     <option value="Assignment">Assignment</option>
                     <option value="Work">Work</option>
                     <option value="Meeting">Meeting</option>
                     <option value="Personal">Personal</option>
                   </select>
+                  {isCategoryInvalid && (
+                    <p id="category-error" className={styles.fieldError}>
+                      Select a category before creating the task.
+                    </p>
+                  )}
                 </div>
               </div>
 

--- a/components/tasks/TaskForm.module.css
+++ b/components/tasks/TaskForm.module.css
@@ -156,6 +156,19 @@
   box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
 }
 
+.selectError,
+.selectError:focus {
+  border-color: #ef4444;
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.16);
+}
+
+.fieldError {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: #f87171;
+}
+
 /* ── Footer ── */
 .footer {
   padding: 16px 24px;


### PR DESCRIPTION
## What changed?

This PR makes the task category selector required in the task form. New task forms now start with an explicit placeholder, use native browser validation, and show a red validation state when the category is left blank.

Closes #64

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring / Tech Debt
- [ ] CI/CD or Configuration changes

## Testing Checklist

- [x] I have run `npm run lint` and resolved all errors.
- [x] I have run `npm run format` to ensure code is formatted.
- [x] I have built the application locally and verified it works.
- [x] Tests pass locally (if applicable).

Verification run:

- `npm run lint`
- `npx prettier --check components/tasks/TaskForm.js components/tasks/TaskForm.module.css`
- `npm run build`
- `git diff --check`

## Security Checklist

- [x] No hardcoded secrets, API keys, or tokens.
- [x] Proper validation for any new user input.
- [x] No unintended data exposure in logs or UI.

## Screenshots (if applicable)

Not included; this is a validation-only task form change.