### PR TITLE
fix: smooth theme transitions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,8 @@
 
 :root,
 [data-theme="dark"] {
+  color-scheme: dark;
+
   /* ===== COLOR SYSTEM — aligned with Linear / DESIGN.md ===== */
   --color-bg-primary: #010102;
   --color-bg-secondary: #0f1011;
@@ -139,6 +141,8 @@
 }
 
 [data-theme="light"] {
+  color-scheme: light;
+
   --color-bg-primary: #f1f5f9;
   --color-bg-secondary: #ffffff;
   --color-bg-tertiary: #e2e8f0;
@@ -196,6 +200,28 @@
 
 [data-theme="light"] .glass-panel {
   background: rgba(255, 255, 255, 0.85);
+}
+
+html.theme-transitioning,
+html.theme-transitioning *,
+html.theme-transitioning *::before,
+html.theme-transitioning *::after {
+  transition:
+    background-color 0.3s ease,
+    border-color 0.3s ease,
+    color 0.3s ease,
+    fill 0.3s ease,
+    stroke 0.3s ease,
+    box-shadow 0.3s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html.theme-transitioning,
+  html.theme-transitioning *,
+  html.theme-transitioning *::before,
+  html.theme-transitioning *::after {
+    transition: none;
+  }
 }
 
 /* Site header mobile nav (Header.js + landing) */

--- a/components/providers/ThemeProvider.js
+++ b/components/providers/ThemeProvider.js
@@ -6,6 +6,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
@@ -21,6 +22,7 @@ const ThemeContext = createContext({
 export function ThemeProvider({ children }) {
   const [theme, setTheme] = useState('dark');
   const [mounted, setMounted] = useState(false);
+  const transitionTimeoutRef = useRef(null);
 
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
@@ -38,7 +40,27 @@ export function ThemeProvider({ children }) {
     localStorage.setItem(STORAGE_KEY, theme);
   }, [theme, mounted]);
 
+  useEffect(() => {
+    return () => {
+      if (transitionTimeoutRef.current) {
+        window.clearTimeout(transitionTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const toggleTheme = useCallback(() => {
+    const root = document.documentElement;
+    root.classList.add('theme-transitioning');
+
+    if (transitionTimeoutRef.current) {
+      window.clearTimeout(transitionTimeoutRef.current);
+    }
+
+    transitionTimeoutRef.current = window.setTimeout(() => {
+      root.classList.remove('theme-transitioning');
+      transitionTimeoutRef.current = null;
+    }, 300);
+
     setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
   }, []);
 

--- a/components/tasks/TaskCard.js
+++ b/components/tasks/TaskCard.js
@@ -105,7 +105,9 @@ export default function TaskCard({
         {task.description ? (
           <p className={styles.description}>{task.description}</p>
         ) : (
-          <p className={`${styles.description} ${styles.descriptionPlaceholder}`}>
+          <p
+            className={`${styles.description} ${styles.descriptionPlaceholder}`}
+          >
             No description added
           </p>
         )}


### PR DESCRIPTION
## What changed?

This PR smooths dark/light theme changes by adding a short global transition class only while the user toggles themes. It transitions background, border, text, fill, stroke, and shadow colors for 0.3s, respects reduced-motion preferences, and avoids running the transition during initial hydration.

Closes #62

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring / Tech Debt
- [ ] CI/CD or Configuration changes

## Testing Checklist

- [x] I have run `npm run lint` and resolved all errors.
- [x] I have run `npm run format` to ensure code is formatted.
- [x] I have built the application locally and verified it works.
- [x] Tests pass locally (if applicable).

Verification run:

- `npm run lint`
- `npx prettier --check app/globals.css components/providers/ThemeProvider.js`
- `npm run build`
- `git diff --check`
- Browser smoke check on the landing page theme toggle

## Security Checklist

- [x] No hardcoded secrets, API keys, or tokens.
- [x] Proper validation for any new user input.
- [x] No unintended data exposure in logs or UI.

## Screenshots (if applicable)

Not included; this is a motion-only theme transition change.