### PR TITLE
feat: display app version in dashboard sidebar footer

### DIFF
--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -1,4 +1,5 @@
 "use client";
+import { version } from "../../package.json";
 
 import { useState, useMemo, useEffect } from "react";
 import styles from "./page.module.css";
@@ -569,6 +570,9 @@ export default function DashboardPage() {
           {activeWorkspace && (
             <WorkspaceActivityFeed workspaceId={activeWorkspace.id} />
           )}
+          <div className={styles.versionFooter}>
+            v{version}
+          </div>
         </aside>
       </div>
 

--- a/app/dashboard/page.module.css
+++ b/app/dashboard/page.module.css
@@ -491,3 +491,15 @@
   font-style: italic;
   font-weight: 450;
 }
+
+/* ── Version Footer ── */
+.versionFooter {
+  margin-top: auto;
+  padding-top: 12px;
+  text-align: center;
+  font-size: 11px;
+  color: var(--color-text-quaternary, var(--color-text-tertiary));
+  opacity: 0.5;
+  font-variant-numeric: tabular-nums;
+  user-select: none;
+}


### PR DESCRIPTION
## What
Adds the app version string (read from `package.json`) at the bottom of the dashboard side panel.

## Why
Users and devs need a quick way to check the running version without digging into package.json.

## How
- Imports `version` directly from `package.json` (Next.js supports this)
- Renders it in a small, subtle footer below the sidebar widgets
- Styled at 11px with low opacity — stays out of the way
- Automatically reflects any version bump in package.json

Closes #63