### PR TITLE
feat: add Mark All as Completed button next to task count

### DIFF
--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -187,6 +187,30 @@ export default function DashboardPage() {
     }
   };
 
+  const handleMarkAllCompleted = async () => {
+    try {
+      const incompleteIds = filteredTasks
+        .filter((t) => t.status !== "completed")
+        .map((t) => t.id);
+
+      for (const id of incompleteIds) {
+        await fetch(`/api/tasks/${id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "completed" }),
+        });
+      }
+
+      setTasks((prev) =>
+        prev.map((t) =>
+          incompleteIds.includes(t.id) ? { ...t, status: "completed" } : t
+        )
+      );
+    } catch (err) {
+      console.error("Failed to mark all tasks as completed:", err);
+    }
+  };
+
   const handleVoiceInput = (text) => {
     setInitialVoiceText(text);
     setIsFormOpen(true);
@@ -487,6 +511,15 @@ export default function DashboardPage() {
               {filteredTasks.length}{" "}
               {filteredTasks.length === 1 ? "task" : "tasks"}
             </span>
+
+            {filteredTasks.some((t) => t.status !== "completed") && (
+              <button
+                className={styles.markAllBtn}
+                onClick={handleMarkAllCompleted}
+              >
+                Mark All Completed
+              </button>
+            )}
 
             {filteredTasks.some((t) => t.status === "completed") && (
               <button

--- a/app/dashboard/page.module.css
+++ b/app/dashboard/page.module.css
@@ -299,6 +299,41 @@
   border-radius: var(--radius-full);
 }
 
+.markAllBtn {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-low-400);
+  background: rgba(16, 185, 129, 0.08);
+  border: 1px solid rgba(16, 185, 129, 0.2);
+  border-radius: var(--radius-full);
+  padding: 4px 12px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.markAllBtn:hover {
+  background: rgba(16, 185, 129, 0.15);
+  border-color: rgba(16, 185, 129, 0.4);
+}
+
+.clearBtn {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-tertiary);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-full);
+  padding: 4px 12px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.clearBtn:hover {
+  color: var(--color-urgent-400);
+  border-color: rgba(244, 63, 94, 0.3);
+  background: rgba(244, 63, 94, 0.06);
+}
+
 /* ── Task list ── */
 .taskList {
   display: flex;


### PR DESCRIPTION
## Summary
Closes #69

Clearing tasks one by one is repetitive when finishing a large project. This adds a secondary button next to the existing "Clear Completed" button that marks all incomplete tasks as completed in one action.

## Changes
- Add `handleMarkAllCompleted()` that batch-updates all incomplete filtered tasks to `completed` status via `PUT /api/tasks/:id`
- Show "Mark All Completed" button only when incomplete tasks exist in the current filter
- Style the button with a green accent (consistent with the completion theme) to visually distinguish from the red-accented "Clear Completed" button
- Also add base styles for the existing `clearBtn` that was only defined in the mobile breakpoint

## Screenshot (conceptual)
```
12 tasks  [Mark All Completed]  [Clear Completed]
```