### PR TITLE
feat: apply custom accent HSL border and glow on high priority tasks

### DIFF
--- a/components/tasks/TaskCard.module.css
+++ b/components/tasks/TaskCard.module.css
@@ -37,7 +37,8 @@
 
 /* ── Priority left accent ── */
 .priority--high {
-  border-left-color: var(--color-urgent-600);
+  border-left: 3px solid hsl(350 85% 55%);
+  box-shadow: inset 3px 0 8px -3px hsl(350 85% 55% / 0.35);
 }
 .priority--medium {
   border-left-color: var(--color-medium-600);


### PR DESCRIPTION
## Summary
Closes #73

High priority tasks should stand out visually without being overly abrasive. The previous border used a CSS variable that could vary across themes and lacked a glow effect.

## Changes
- Replace `border-left-color` with an explicit HSL value (`hsl(350 85% 55%)`) for a vibrant, theme-independent red accent
- Add an inset `box-shadow` glow that softly bleeds the accent color inward, making the left hairline feel luminous
- The combination of solid border + subtle glow draws the eye without clashing with the rest of the card design
- Medium and low priority borders remain unchanged

## Before
```css
.priority--high {
  border-left-color: var(--color-urgent-600);
}
```

## After
```css
.priority--high {
  border-left: 3px solid hsl(350 85% 55%);
  box-shadow: inset 3px 0 8px -3px hsl(350 85% 55% / 0.35);
}
```