### PR TITLE
feat: add wake-word task activation

### DIFF
--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import styles from "./page.module.css";
 import Button from "@/components/ui/Button";
 import { Plus } from "lucide-react";
 import TaskCard from "@/components/tasks/TaskCard";
 import CalendarView from "@/components/ui/CalendarView";
 import VoiceMic from "@/components/ui/VoiceMic";
+import WakeWordListener from "@/components/ui/WakeWordListener";
 import TaskForm from "@/components/tasks/TaskForm";
 import WorkspaceSelector from "@/components/ui/WorkspaceSelector";
 import WorkspaceModal from "@/components/ui/WorkspaceModal";
@@ -187,10 +188,11 @@ export default function DashboardPage() {
     }
   };
 
-  const handleVoiceInput = (text) => {
+  const handleVoiceInput = useCallback((text) => {
+    setEditingTask(null);
     setInitialVoiceText(text);
     setIsFormOpen(true);
-  };
+  }, []);
 
   const handleSaveTask = async (taskData) => {
     try {
@@ -295,6 +297,12 @@ export default function DashboardPage() {
             onSelect={setActiveWorkspace}
             onCreateClick={() => setWorkspaceModalMode("create")}
             onManageClick={() => setWorkspaceModalMode("manage")}
+          />
+          <WakeWordListener
+            onWakeWord={handleVoiceInput}
+            paused={
+              isFormOpen || Boolean(selectedTask) || Boolean(workspaceModalMode)
+            }
           />
           <VoiceMic onResult={handleVoiceInput} />
           <Button

--- a/components/ui/WakeWordListener.js
+++ b/components/ui/WakeWordListener.js
@@ -1,0 +1,268 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Mic, MicOff } from 'lucide-react';
+import styles from './WakeWordListener.module.css';
+
+const STORAGE_KEY = 'remindkaro:wake-word-enabled';
+const RESTART_DELAY_MS = 750;
+const WAKE_WORD_PATTERN = /^\s*hey[\s,-]+remind\b[\s,:-]*(.*)$/i;
+
+function persistEnabledState(isEnabled) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(isEnabled));
+  } catch {
+    // Wake-word listening still works when storage is unavailable.
+  }
+}
+
+export default function WakeWordListener({ onWakeWord, paused = false }) {
+  const [isSupported, setIsSupported] = useState(null);
+  const [isEnabled, setIsEnabled] = useState(false);
+  const [isListening, setIsListening] = useState(false);
+  const [statusMessage, setStatusMessage] = useState('');
+
+  const recognitionRef = useRef(null);
+  const restartTimerRef = useRef(null);
+  const startRecognitionRef = useRef(null);
+  const shouldListenRef = useRef(false);
+  const onWakeWordRef = useRef(onWakeWord);
+
+  useEffect(() => {
+    onWakeWordRef.current = onWakeWord;
+  }, [onWakeWord]);
+
+  useEffect(() => {
+    const SpeechRecognition =
+      window.SpeechRecognition || window.webkitSpeechRecognition;
+
+    if (!SpeechRecognition) {
+      setIsSupported(false);
+      setStatusMessage('Wake-word recognition is unavailable in this browser.');
+      return undefined;
+    }
+
+    setIsSupported(true);
+
+    const recognition = new SpeechRecognition();
+    recognition.continuous = true;
+    recognition.interimResults = false;
+    recognition.lang = 'en-US';
+
+    const clearRestartTimer = () => {
+      if (restartTimerRef.current) {
+        window.clearTimeout(restartTimerRef.current);
+        restartTimerRef.current = null;
+      }
+    };
+
+    const startRecognition = () => {
+      if (!shouldListenRef.current || recognitionRef.current !== recognition) {
+        return;
+      }
+
+      clearRestartTimer();
+
+      try {
+        recognition.start();
+      } catch (error) {
+        if (error?.name !== 'InvalidStateError') {
+          setStatusMessage('Unable to start wake-word listening.');
+        }
+      }
+    };
+
+    startRecognitionRef.current = startRecognition;
+
+    recognition.onstart = () => {
+      if (!shouldListenRef.current) {
+        recognition.abort();
+        return;
+      }
+
+      setIsListening(true);
+      setStatusMessage('Listening for “Hey Remind”.');
+    };
+
+    recognition.onresult = (event) => {
+      if (!shouldListenRef.current) return;
+
+      for (
+        let index = event.resultIndex;
+        index < event.results.length;
+        index++
+      ) {
+        const result = event.results[index];
+        if (!result.isFinal) continue;
+
+        const transcript = result[0].transcript.trim();
+        const match = transcript.match(WAKE_WORD_PATTERN);
+        if (!match) continue;
+
+        const command = match[1].trim();
+        const taskRequest = command ? `Remind ${command}` : '';
+
+        shouldListenRef.current = false;
+        clearRestartTimer();
+        recognition.stop();
+        setStatusMessage('Wake word detected. Opening a new task.');
+        onWakeWordRef.current?.(taskRequest);
+        return;
+      }
+    };
+
+    recognition.onerror = (event) => {
+      setIsListening(false);
+
+      if (event.error === 'aborted' || event.error === 'no-speech') return;
+
+      if (
+        event.error === 'not-allowed' ||
+        event.error === 'service-not-allowed'
+      ) {
+        shouldListenRef.current = false;
+        setIsEnabled(false);
+        persistEnabledState(false);
+        setStatusMessage(
+          'Microphone permission was denied. Enable it to use “Hey Remind”.'
+        );
+        return;
+      }
+
+      if (event.error === 'audio-capture') {
+        shouldListenRef.current = false;
+        setIsEnabled(false);
+        persistEnabledState(false);
+        setStatusMessage('No microphone is available for wake-word listening.');
+        return;
+      }
+
+      setStatusMessage('Wake-word listening was interrupted. Retrying…');
+    };
+
+    recognition.onend = () => {
+      setIsListening(false);
+
+      if (!shouldListenRef.current) return;
+
+      clearRestartTimer();
+      restartTimerRef.current = window.setTimeout(
+        startRecognition,
+        RESTART_DELAY_MS
+      );
+    };
+
+    recognitionRef.current = recognition;
+
+    try {
+      setIsEnabled(window.localStorage.getItem(STORAGE_KEY) === 'true');
+    } catch {
+      setIsEnabled(false);
+    }
+
+    return () => {
+      shouldListenRef.current = false;
+      clearRestartTimer();
+      startRecognitionRef.current = null;
+      recognition.onstart = null;
+      recognition.onresult = null;
+      recognition.onerror = null;
+      recognition.onend = null;
+      try {
+        recognition.abort();
+      } catch {
+        // Recognition may already be stopped.
+      }
+      recognitionRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const shouldListen = isSupported === true && isEnabled && !paused;
+    shouldListenRef.current = shouldListen;
+
+    if (restartTimerRef.current) {
+      window.clearTimeout(restartTimerRef.current);
+      restartTimerRef.current = null;
+    }
+
+    if (shouldListen) {
+      startRecognitionRef.current?.();
+      return;
+    }
+
+    if (isEnabled && paused) {
+      setStatusMessage('Wake-word listening is paused while a modal is open.');
+    }
+
+    try {
+      recognitionRef.current?.abort();
+    } catch {
+      // Recognition may already be stopped.
+    }
+  }, [isEnabled, isSupported, paused]);
+
+  const handleToggle = useCallback(() => {
+    if (isSupported !== true) return;
+
+    const nextEnabled = !isEnabled;
+    setIsEnabled(nextEnabled);
+    persistEnabledState(nextEnabled);
+
+    if (!nextEnabled) {
+      shouldListenRef.current = false;
+      setStatusMessage('Wake-word listening is off.');
+      try {
+        recognitionRef.current?.abort();
+      } catch {
+        // Recognition may already be stopped.
+      }
+      return;
+    }
+
+    setStatusMessage('Requesting microphone access…');
+    shouldListenRef.current = !paused;
+    if (!paused) startRecognitionRef.current?.();
+  }, [isEnabled, isSupported, paused]);
+
+  const label =
+    isSupported === false
+      ? 'Hey Remind unavailable'
+      : !isEnabled
+        ? 'Enable Hey Remind'
+        : paused
+          ? 'Hey Remind paused'
+          : isListening
+            ? 'Hey Remind on'
+            : 'Starting Hey Remind';
+
+  return (
+    <div className={styles.wrapper}>
+      <button
+        type="button"
+        className={`${styles.toggle} ${isEnabled ? styles.enabled : ''} ${
+          isListening ? styles.listening : ''
+        }`}
+        onClick={handleToggle}
+        disabled={isSupported !== true}
+        aria-label={label}
+        aria-pressed={isEnabled}
+      >
+        {isEnabled ? (
+          <Mic size={15} aria-hidden="true" />
+        ) : (
+          <MicOff size={15} aria-hidden="true" />
+        )}
+        <span>{label}</span>
+        {isEnabled && <span className={styles.statusDot} aria-hidden="true" />}
+      </button>
+      <span
+        className={styles.tooltip}
+        role={statusMessage.includes('denied') ? 'alert' : 'status'}
+        aria-live="polite"
+      >
+        {statusMessage || 'Say “Hey Remind” to open a new task.'}
+      </span>
+    </div>
+  );
+}

--- a/components/ui/WakeWordListener.module.css
+++ b/components/ui/WakeWordListener.module.css
@@ -1,0 +1,121 @@
+.wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.toggle {
+  min-height: 40px;
+  padding: 0 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border: 1px solid var(--color-border-medium);
+  border-radius: var(--linear-radius-md);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-secondary);
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast),
+    background var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.toggle:hover:not(:disabled) {
+  color: var(--color-text-primary);
+  border-color: var(--color-border-strong);
+  background: var(--color-bg-tertiary);
+}
+
+.toggle:focus-visible {
+  outline: 2px solid var(--linear-primary-hover);
+  outline-offset: 2px;
+}
+
+.toggle:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.enabled {
+  color: var(--linear-primary-hover);
+  border-color: rgba(94, 106, 210, 0.35);
+  background: rgba(94, 106, 210, 0.08);
+}
+
+.listening {
+  box-shadow: 0 0 14px rgba(94, 106, 210, 0.2);
+}
+
+.statusDot {
+  width: 6px;
+  height: 6px;
+  flex-shrink: 0;
+  border-radius: var(--radius-full);
+  background: var(--linear-primary-hover);
+  box-shadow: 0 0 0 3px rgba(94, 106, 210, 0.12);
+}
+
+.listening .statusDot {
+  animation: wakePulse 1.8s ease-in-out infinite;
+}
+
+.tooltip {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  z-index: 20;
+  width: max-content;
+  max-width: 260px;
+  padding: 6px 10px;
+  transform: translateX(-50%);
+  border: 1px solid var(--color-border-medium);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  font-size: 11px;
+  line-height: 1.4;
+  text-align: center;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.wrapper:hover .tooltip,
+.wrapper:focus-within .tooltip {
+  opacity: 1;
+}
+
+@keyframes wakePulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  50% {
+    opacity: 0.55;
+    transform: scale(0.75);
+  }
+}
+
+@media (max-width: 640px) {
+  .wrapper,
+  .toggle {
+    width: 100%;
+  }
+
+  .tooltip {
+    left: 0;
+    bottom: auto;
+    top: calc(100% + 8px);
+    transform: none;
+  }
+}


### PR DESCRIPTION
## What changed

- Added an opt-in `Hey Remind` listener to the dashboard with a persisted `localStorage` preference.
- Added continuous Web Speech API recognition that only accepts final transcripts beginning with the exact wake phrase, then forwards the remaining command into the existing task form flow.
- Paused recognition while any dashboard modal is open and resumed it after the modal closes.
- Added cleanup, automatic recovery after normal recognition shutdowns, unsupported-browser handling, denied-permission handling, and no-microphone handling.
- Added an accessible, responsive dashboard toggle with visible listening and paused states.

## Why

Voice task entry previously required clicking the microphone every time. After a user explicitly enables the feature and grants microphone permission, they can say `Hey Remind` to open a new task without another click. Requiring an explicit opt-in keeps browser permission behavior safe and predictable.

## Validation

- `npm run lint`
- `NEXT_PUBLIC_API_URL=http://localhost:5000 npm run build`
- Targeted Prettier check for the new component and CSS module
- Wake-phrase matching checks covering exact matches and false-positive rejection

## Known baseline

The repository-wide `npm run format:check` currently reports pre-existing formatting issues in 36 files under `app/`. This PR keeps its formatting scope limited; both newly added files pass Prettier.

Closes #90
